### PR TITLE
feat: setup of swagger & installed it

### DIFF
--- a/TaskManager/settings.py
+++ b/TaskManager/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'drf_yasg',
     'tasks'
 ]
 

--- a/TaskManager/urls.py
+++ b/TaskManager/urls.py
@@ -1,7 +1,25 @@
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Task Manager API",
+      default_version='v1',
+      description="API description",
+      terms_of_service="https://www.google.com/policies/terms/",
+      contact=openapi.Contact(email="contact@yourdomain.com"),
+      license=openapi.License(name="BSD License"),
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', include('tasks.urls')),
+    path('api/', include('tasks.urls')),  
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,11 @@
 asgiref==3.8.1
 Django==5.0.6
 djangorestframework==3.15.1
+drf-yasg==1.21.7
+inflection==0.5.1
+packaging==24.1
+pytz==2024.1
+PyYAML==6.0.1
+setuptools==70.0.0
 sqlparse==0.5.0
+uritemplate==4.1.1


### PR DESCRIPTION
feat: setup Swagger API documentation using `drf-yasg`

### Description
This commit introduces the setup of Swagger API documentation for the Django project. `drf-yasg` (Yet Another Swagger Generator) has been integrated to automatically generate and display API documentation.

### Changes Made
- Installed `drf-yasg` library for Django
- Configured Swagger UI and Redoc endpoints in `urls.py`
- Updated project settings and URL configurations for Swagger documentation

### Next Steps
- Verify Swagger documentation integration
- Customize Swagger settings and API descriptions as needed
- Ensure all API endpoints are properly documented in Swagger

This commit enhances the project by providing interactive API documentation, improving clarity and ease of use for developers and consumers of the API.

Remember to follow our [GitHub Community Guidelines](https://help.github.com/articles/github-community-guidelines/) when contributing to this repository.
